### PR TITLE
.travis.yml: Add fedora-25

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
     - BASE_DISTRO=fedora-22
     - BASE_DISTRO=fedora-23
     - BASE_DISTRO=fedora-24
+    - BASE_DISTRO=fedora-25
     - BASE_DISTRO=opensuse-13.2
     - BASE_DISTRO=opensuse-42.1
     - BASE_DISTRO=ubuntu-14.04


### PR DESCRIPTION
Since fedora 25 was added to the base containers, add it here as well.

Signed-off-by: Randy Witt <randy.e.witt@linux.intel.com>