### PR TITLE
.travis.yml: Add opensuse-42.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
     - BASE_DISTRO=fedora-25
     - BASE_DISTRO=opensuse-13.2
     - BASE_DISTRO=opensuse-42.1
+    - BASE_DISTRO=opensuse-42.2
     - BASE_DISTRO=ubuntu-14.04
     - BASE_DISTRO=ubuntu-16.04
     - BASE_DISTRO=ubuntu-16.10


### PR DESCRIPTION
Since opensuse 42.2 was added to the base containers, add it here as
well.

Signed-off-by: Randy Witt <randy.e.witt@linux.intel.com>