### PR TITLE
runtests.sh: Don't use "-it" for docker run

### DIFF
--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -26,7 +26,7 @@ for i in run-*.sh; do
     # get absolute path to it
     LOCAL_WDIR=$(readlink -f ${LOCAL_WDIR})
     cp $i $LOCAL_WDIR
-    docker run -it --rm  -v $LOCAL_WDIR:/workdir $IMAGE \
+    docker run --rm  -v $LOCAL_WDIR:/workdir $IMAGE \
 	--workdir=/workdir --cmd="/workdir/$i"
     RET=$?
     if [ ${RET} != 0 ]; then


### PR DESCRIPTION
When using "-t" with docker run, stderr comes out as stdout. Since this is a
non-interactive test that shouldn't need a tty, don't use "-it".

Signed-off-by: Randy Witt <randy.e.witt@linux.intel.com>