### PR TITLE
Fix runtests.sh failure when SELinux is enabled

### DIFF
--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -26,7 +26,7 @@ for i in run-*.sh; do
     # get absolute path to it
     LOCAL_WDIR=$(readlink -f ${LOCAL_WDIR})
     cp $i $LOCAL_WDIR
-    docker run --rm  -v $LOCAL_WDIR:/workdir $IMAGE \
+    docker run --rm  -v $LOCAL_WDIR:/workdir:Z $IMAGE \
 	--workdir=/workdir --cmd="/workdir/$i"
     RET=$?
     if [ ${RET} != 0 ]; then


### PR DESCRIPTION
When using Docker with SELinux enabled on the host, volume mounted files
and directories must be properly labelled. Correct labelling can be
performed automatically by appending a :Z to the docker run volume mount
option. This change updates the workdir volume mount option in
runtests.sh to automatically label it properly for SELinux.

Signed-off-by: John Akre <john.w.akre@intel.com>