### PR TITLE
poky-entry: make compatible with standard docker invocation

### DIFF
--- a/tests/run-dumb-init-check.sh
+++ b/tests/run-dumb-init-check.sh
@@ -22,7 +22,7 @@
 
 username="usersetup"
 username_width=${#username}
-expected='1 usersetup /usr/bin/dumb-init -- /usr/bin/poky-entry.py --workdir=/workdir --cmd=/workdir/run-dumb-init-check.sh'
+expected='1 usersetup /usr/bin/dumb-init -- /usr/bin/poky-entry.py /workdir/run-dumb-init-check.sh'
 actual=`ps -w -w h -C dumb-init -o pid:1,user:$username_width,args`
 
 if [ "$expected" != "$actual" ]; then
@@ -31,5 +31,12 @@ if [ "$expected" != "$actual" ]; then
     printf "actual:\n%s\n" "$actual"
     printf "all:\n"
     ps -w -w -A -o pid,user:$username_width,args
+    exit 1
+fi
+
+if [ "$(pwd)" != "/workdir" ] ; then
+    printf "expected workdir not found\n"
+    printf "expected:\n%s\n" "/workdir"
+    printf "actual:\n%s\n" "$(pwd)"
     exit 1
 fi

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -25,9 +25,12 @@ for i in run-*.sh; do
     LOCAL_WDIR=$(mktemp -d  wdir_XXXXX)
     # get absolute path to it
     LOCAL_WDIR=$(readlink -f ${LOCAL_WDIR})
+    chmod o+x $LOCAL_WDIR
     cp $i $LOCAL_WDIR
-    docker run --rm -t -v $LOCAL_WDIR:/workdir:Z $IMAGE \
-	--workdir=/workdir --cmd="/workdir/$i"
+    docker run --rm -t -v $LOCAL_WDIR:/workdir \
+	--workdir /workdir \
+	$IMAGE \
+	/workdir/$i
     RET=$?
     if [ ${RET} != 0 ]; then
 	echo "Test $i failed"


### PR DESCRIPTION
This had two issues:
* the command to execute was expected to be passed via --cmd, rather
  than just the remaining arguments as per usual practice when
  using 'docker run' to start a container
* it ignored any --workdir passed via the docker command, and instead
  expected the workdir to be passed as an argument to the entrypoint

Both are non-standard behaviour, and in particular conflict with
the Jenkins docker plugin's expected use of docker images, as that
relies on standard behaviour.

We now:
* (try to) check if a --workdir was given in the docker arguments,
  by checking if the current directory is different from the image's
  default '/home/yoctouser'
* accept additional arguments without a --cmd flag. Any remaining
  arguments now specify the command (and its optional arguments)
  to run

Signed-off-by: André Draszik <andre.draszik@jci.com>