### PR TITLE
ENTRYPOINT compatibility and Ubuntu dash fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,12 @@ ADD https://raw.githubusercontent.com/crops/extsdk-container/master/restrict_use
 COPY poky-entry.py poky-launch.sh /usr/bin/
 COPY sudoers.usersetup /etc/
 
+# For ubuntu, do not use dash.
+RUN which dash &> /dev/null && (\
+    echo "dash dash/sh boolean false" | debconf-set-selections && \
+    DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash) || \
+    echo "Skipping dash reconfigure (not applicable)"
+
 # We remove the user because we add a new one of our own.
 # The usersetup user is solely for adding a new user that has the same uid,
 # as the workspace. 70 is an arbitrary *low* unused uid on debian.

--- a/poky-launch.sh
+++ b/poky-launch.sh
@@ -16,7 +16,7 @@ workdir=$1
 shift
 cd $workdir
 if [ $# -gt 0 ]; then
-    exec bash -c "$*"
+    exec bash -c "$@"
 else
     exec bash -i
 fi


### PR DESCRIPTION
This merge adds two things:

1. Extends the ENTRYPOINT behavior of #34 to include multi-line scripts by retaining line endings.
2. Adds a check for dash to not use it where applicable because of compatibility problems with some layers and dash.

For (1), this also provides a fix for situations like #24.  You can verify this by having a `test.sh` file:

```
sh -c if [ -x /usr/local/bin/bash ]; then
	exec /usr/local/bin/bash 
elif [ -x /usr/bin/bash ]; then
	exec /usr/bin/bash 
elif [ -x /bin/bash ]; then
	exec /bin/bash 
elif [ -x /usr/local/bin/sh ]; then
	exec /usr/local/bin/sh 
elif [ -x /usr/bin/sh ]; then
	exec /usr/bin/sh 
elif [ -x /bin/sh ]; then
	exec /bin/sh 
elif [ -x /busybox/sh ]; then
	exec /busybox/sh 
else
	echo shell not found
	# exit 1
fi
```

And then run the command:

```
docker run -it --name gitlabtest crops/poky:ubuntu-18.04 $(cat test.sh)
```
