### PR TITLE
Sync distros with yocto-dockerfiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,18 @@ env:
     - BASE_DISTRO=centos-7
     - BASE_DISTRO=debian-8
     - BASE_DISTRO=debian-9
+    - BASE_DISTRO=debian-10
     - BASE_DISTRO=fedora-27
     - BASE_DISTRO=fedora-28
-    - BASE_DISTRO=opensuse-42.3
+    - BASE_DISTRO=fedora-29
+    - BASE_DISTRO=fedora-30
     - BASE_DISTRO=opensuse-15.0
+    - BASE_DISTRO=opensuse-15.1
     - BASE_DISTRO=ubuntu-14.04
     - BASE_DISTRO=ubuntu-16.04
     - BASE_DISTRO=ubuntu-18.04
     - BASE_DISTRO=ubuntu-18.10
+    - BASE_DISTRO=ubuntu-19.04
 
   global:
     - REPO=crops/poky


### PR DESCRIPTION
Add:
  - debian-10
  - fedora-29
  - fedora-30
  - opensuse-15.1
  - ubuntu-19.04

Drop:
  - opensuse-42.3

Signed-off-by: Tim Orling <timothy.t.orling@linux.intel.com>