### PR TITLE
README.md: run command with SELinux enforcing

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ point.
     ```
     docker run --rm -it -v /home/myuser/mystuff:/workdir crops/poky --workdir=/workdir
     ```
+    or, if you have SELinux in enforcing mode:
+    ```
+    docker run --rm -it -v /home/myuser/mystuff:/workdir:Z crops/poky --workdir=/workdir
+    ```
     
   * **Windows/Mac**
   


### PR DESCRIPTION
When SELinux is in enforcing mode, the user in the container can't create or modify files in workdir, unless they are correctly labelled. See:
https://github.com/crops/poky-container/commit/e2daa6a2fa1acdeae15241644531643b259d18da
Provide run command line to clarify.