### PR TITLE
deploy.sh: Deploy when event is 'schedule'

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -25,7 +25,7 @@ fi
 
 # Don't deploy on pull requests because it could just be junk code that won't
 # get merged
-if ([ "${GITHUB_EVENT_NAME}" = "push" ] || [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]) && [ "${GITHUB_REF}" = "refs/heads/master" ]; then
+if ([ "${GITHUB_EVENT_NAME}" = "push" ] || [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] || [ "${GITHUB_EVENT_NAME}" = "schedule" ) && [ "${GITHUB_REF}" = "refs/heads/master" ]; then
     echo $DOCKER_PASSWORD | ${ENGINE_CMD} login -u $DOCKER_USERNAME --password-stdin
     ${ENGINE_CMD} push ${REPO}:${BASE_DISTRO}
 


### PR DESCRIPTION
Since 'github/workflows: build every Saturday at 01:42 UTC' builds were
properly being scheduled, but not deployed.

Signed-off-by: Tim Orling <tim.orling@konsulko.com>