### PR TITLE
Alma Linux: add alma-8 to replace for centos-8

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -19,8 +19,8 @@ jobs:
       fail-fast: false
       matrix:
         base_distro: [
+                      alma-8,
                       centos-7,
-                      centos-8,
                       debian-9,
                       debian-10,
                       debian-11,

--- a/distro-entry.sh
+++ b/distro-entry.sh
@@ -1,17 +1,8 @@
 #!/bin/bash
 # Copyright (C) 2019 Intel Corporation
+# Copyright (C) 2022 Konsulko Group
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License version 2 as
-# published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
+# SPDX-License-Identifier: GPL-2.0-only
 
 # This entry point is so that we can do distro specific changes to the launch.
 if [ "$(uname -m)" = "aarch64" ]; then
@@ -24,6 +15,9 @@ fi
 if [ -e /opt/poky/3.1.13/${SETUPSCRIPT} ]; then
     # Buildtools has been installed so enable it
     . /opt/poky/3.1.13/${SETUPSCRIPT} || exit 1
+elif [ -e /opt/poky/4.0/${SETUPSCRIPT} ]; then
+    # Buildtools(-make) has been installed so enable it
+    . /opt/poky/4.0/${SETUPSCRIPT} || exit 1
 fi
 
 exec "$@"

--- a/tests/distro-check.sh
+++ b/tests/distro-check.sh
@@ -26,8 +26,8 @@ BASE_DISTRO="$3"
 
 declare -A distros
 
+distros["alma-8"]="AlmaLinux 8"
 distros["centos-7"]="CentOS Linux 7 (Core)"
-distros["centos-8"]="CentOS Linux 8"
 distros["debian-9"]="Debian GNU/Linux 9 (stretch)"
 distros["debian-10"]="Debian GNU/Linux 10 (buster)"
 distros["debian-11"]="Debian GNU/Linux 11 (bullseye)"


### PR DESCRIPTION
centos-8 was EOL in December 2021 and is no longer fetchable.

Signed-off-by: Tim Orling <tim.orling@konsulko.com>