### PR TITLE
deploy.sh: fix typo

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -25,7 +25,7 @@ fi
 
 # Don't deploy on pull requests because it could just be junk code that won't
 # get merged
-if ([ "${GITHUB_EVENT_NAME}" = "push" ] || [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] || [ "${GITHUB_EVENT_NAME}" = "schedule" ) && [ "${GITHUB_REF}" = "refs/heads/master" ]; then
+if ([ "${GITHUB_EVENT_NAME}" = "push" ] || [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] || [ "${GITHUB_EVENT_NAME}" = "schedule" ]) && [ "${GITHUB_REF}" = "refs/heads/master" ]; then
     echo $DOCKER_PASSWORD | ${ENGINE_CMD} login -u $DOCKER_USERNAME --password-stdin
     ${ENGINE_CMD} push ${REPO}:${BASE_DISTRO}
 


### PR DESCRIPTION
Missing ']' is causing scheduled builds to not push.

Signed-off-by: Tim Orling <tim.orling@konsulko.com>