### PR TITLE
Add Ubuntu 22.04 LTS

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -29,7 +29,8 @@ jobs:
                       opensuse-15.2,
                       ubuntu-16.04,
                       ubuntu-18.04,
-                      ubuntu-20.04
+                      ubuntu-20.04,
+                      ubuntu-22.04
         ]
     env:
       BASE_DISTRO: ${{ matrix.base_distro }}

--- a/tests/distro-check.sh
+++ b/tests/distro-check.sh
@@ -37,6 +37,7 @@ distros["opensuse-15.2"]="openSUSE Leap 15.2"
 distros["ubuntu-16.04"]="Ubuntu 16.04"
 distros["ubuntu-18.04"]="Ubuntu 18.04"
 distros["ubuntu-20.04"]="Ubuntu 20.04"
+distros["ubuntu-22.04"]="Ubuntu 22.04"
 
 # If the distro is unknown it is a failure
 if [ "${distros[${BASE_DISTRO}]}" = "" ]; then


### PR DESCRIPTION
Ubuntu 22.04 LTS will be released [tomorrow (Thursday 21st of April 2022)](https://discourse.ubuntu.com/t/jammy-jellyfish-release-schedule/23906). Make sure poky is available from day 1.