### PR TITLE
Ubuntu: replace 16.04 with 22.04

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -27,9 +27,9 @@ jobs:
                       fedora-34,
                       fedora-35,
                       opensuse-15.2,
-                      ubuntu-16.04,
                       ubuntu-18.04,
-                      ubuntu-20.04
+                      ubuntu-20.04,
+                      ubuntu-22.04
         ]
     env:
       BASE_DISTRO: ${{ matrix.base_distro }}

--- a/tests/distro-check.sh
+++ b/tests/distro-check.sh
@@ -34,9 +34,9 @@ distros["debian-11"]="Debian GNU/Linux 11 (bullseye)"
 distros["fedora-34"]="Fedora 34 (Container Image)"
 distros["fedora-35"]="Fedora Linux 35 (Container Image)"
 distros["opensuse-15.2"]="openSUSE Leap 15.2"
-distros["ubuntu-16.04"]="Ubuntu 16.04"
 distros["ubuntu-18.04"]="Ubuntu 18.04"
 distros["ubuntu-20.04"]="Ubuntu 20.04"
+distros["ubuntu-22.04"]="Ubuntu 22.04"
 
 # If the distro is unknown it is a failure
 if [ "${distros[${BASE_DISTRO}]}" = "" ]; then


### PR DESCRIPTION
Ubuntu "Jammy Jellyfish" 22.04 has been released, with long-term support
until at least 2027 (maintenance) and 2032 (extended security
maintenance).

https://ubuntu.com/about/release-cycle
https://ubuntu.com/blog/ubuntu-22-04-lts-released

Although ubuntu-16.04 is in Extended Security Maintenance until 2026, it
is holding us back from adding git-lfs (see
https://github.com/crops/yocto-dockerfiles/pull/40).

Signed-off-by: Tim Orling <tim.orling@konsulko.com>