### PR TITLE
README.md: fix link to Yocto Project docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,4 @@ point.
   pokyuser@3bbac563cacd:/workdir$
   ```
   At this point you should be able to follow the same instructions as described
-  in https://www.yoctoproject.org/docs/current/yocto-project-qs/yocto-project-qs.html#releases.
+  in https://docs.yoctoproject.org/brief-yoctoprojectqs/index.html


### PR DESCRIPTION
With the change to building the docs with Sphinx, the Yocto Project documentation also changed URLs to https://docs.yoctoproject.org/

Fixes:
https://github.com/crops/poky-container/issues/85

Signed-off-by: Tim Orling <tim.orling@konsulko.com>