### PR TITLE
Add helper script and integrate with ssh-agent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,11 @@ ADD https://raw.githubusercontent.com/crops/extsdk-container/master/restrict_use
 COPY distro-entry.sh poky-entry.py poky-launch.sh /usr/bin/
 COPY sudoers.usersetup /etc/
 
+RUN echo -e "\n# ssh-agent socket bind-mounted from host\n"\
+"if [ -s /tmp/ssh-auth-sock ]; then\n"\
+"    export SSH_AUTH_SOCK=/tmp/ssh-auth-sock\n"\
+"fi\n" >> /etc/skel/.bashrc
+
 # For ubuntu, do not use dash.
 RUN which dash &> /dev/null && (\
     echo "dash dash/sh boolean false" | debconf-set-selections && \

--- a/poky-container
+++ b/poky-container
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+usage() {
+cat << EOF
+Usage:
+    poky-container list
+                List available images
+
+    poky-container run IMAGE [HOST_WORKDIR]
+                Run the selected image on a specific location
+
+Parameters:
+    IMAGE           The name of the image to run
+    HOST_WORKDIR    The working directory, ie, location if the workspace
+                    on the host, which will show as /workdir in the
+                    container.
+                    By default, the current working directory is used.
+
+EOF
+}
+
+
+list() {
+cat << EOF
+AlmaLinux:
+    alma-8
+
+CentOS:
+    centos-7 centos-8
+
+Debian:
+    debian-9 debian-10 debian-11
+
+Fedora:
+    fedora-33 fedora-34 fedora-35 fedora-36
+
+OpenSuse:
+    opensuse-15.2 opensuse-15.3
+
+Ubuntu:
+    ubuntu-16.04 ubuntu-18.04 ubuntu-20.04 ubuntu-22.04
+
+Other:
+    latest
+
+EOF
+}
+
+run() {
+    CONTAINER_WORKDIR=/workdir
+    HOST_WORKDIR=$(readlink -f .)
+    if [ $# -eq 2 ]; then
+        HOST_WORKDIR=$(readlink -f $2)
+    elif [ $# -ne 1 ]; then
+        echo "Error: Invalid arguments"
+        usage
+        exit 1
+    fi
+    IMAGE=$1
+
+    docker run --rm -it -v $HOST_WORKDIR:$CONTAINER_WORKDIR \
+    crops/poky:$IMAGE --workdir=$CONTAINER_WORKDIR
+}
+
+
+CMD=$1
+shift
+
+case $CMD in
+    list)
+        list
+        ;;
+    run)
+        run $@
+        ;;
+    *)
+        usage
+        ;;
+esac
+
+
+
+

--- a/poky-container
+++ b/poky-container
@@ -23,10 +23,10 @@ EOF
 list() {
 cat << EOF
 AlmaLinux:
-    alma-8
+    alma-8 alma-9
 
 CentOS:
-    centos-7 centos-8
+    centos-7
 
 Debian:
     debian-9 debian-10 debian-11
@@ -35,13 +35,10 @@ Fedora:
     fedora-33 fedora-34 fedora-35 fedora-36
 
 OpenSuse:
-    opensuse-15.2 opensuse-15.3
+    opensuse-15.2 opensuse-15.3 opensuse-15.4
 
 Ubuntu:
     ubuntu-16.04 ubuntu-18.04 ubuntu-20.04 ubuntu-22.04
-
-Other:
-    latest
 
 EOF
 }

--- a/poky-container
+++ b/poky-container
@@ -58,7 +58,14 @@ run() {
     fi
     IMAGE=$1
 
+    SSH_AUTH_SOCK_MOUNT=""
+    if [ -z "$SSH_AUTH_SOCK" ]; then
+        eval $(ssh-agent)
+        SSH_AUTH_SOCK_MOUNT="--mount type=bind,source=$(readlink -f $SSH_AUTH_SOCK),destination=/tmp/ssh-auth-sock"
+    fi
+
     docker run --rm -it -v $HOST_WORKDIR:$CONTAINER_WORKDIR \
+    $SSH_AUTH_SOCK_MOUNT \
     crops/poky:$IMAGE --workdir=$CONTAINER_WORKDIR
 }
 


### PR DESCRIPTION





Added a script, poky-container, which can be used to simplify the listing and launching of the available containers.

## Listing available containers

Note: the list of containers is maintained by hand.

```
 poky-container list
AlmaLinux:
    alma-8 alma-9

CentOS:
    centos-7

Debian:
    debian-9 debian-10 debian-11

Fedora:
    fedora-33 fedora-34 fedora-35 fedora-36

OpenSuse:
    opensuse-15.2 opensuse-15.3 opensuse-15.4

Ubuntu:
    ubuntu-16.04 ubuntu-18.04 ubuntu-20.04 ubuntu-22.04
```

## Launching a container

```
user@host$ poky-container run ubuntu-20.04
...
pokyuser@4da677d43c61:/workdir$ 
```

## Basic help

```
user@host$ poky-container help
Usage:
    poky-container list
                List available images

    poky-container run IMAGE [HOST_WORKDIR]
                Run the selected image on a specific location

Parameters:
    IMAGE           The name of the image to run
    HOST_WORKDIR    The working directory, ie, location if the workspace
                    on the host, which will show as /workdir in the
                    container.
                    By default, the current working directory is used.
```

## ssh-agent integration

When launching the container, if SSH_AUTH_SOCK is set, the socket is bind-mounted in the container too and `~/.bashrc` in the container recreates the SSH_AUTH_SOCK variable.

Feel free to pick any of the changes or suggest improvements. 
Thanks.