### PR TITLE
distro-entry.sh: Bump RELEASE to 4.1

### DIFF
--- a/distro-entry.sh
+++ b/distro-entry.sh
@@ -4,6 +4,8 @@
 #
 # SPDX-License-Identifier: GPL-2.0-only
 
+RELEASE="4.1"
+
 # This entry point is so that we can do distro specific changes to the launch.
 if [ "$(uname -m)" = "aarch64" ]; then
     SETUPSCRIPT="environment-setup-aarch64-pokysdk-linux"
@@ -12,12 +14,12 @@ elif [ "$(uname -m)" = "x86_64" ]; then
 fi
 
 # This entry point is so that we can do distro specific changes to the launch.
-if [ -e /opt/poky/3.1.13/${SETUPSCRIPT} ]; then
+if [ -e /opt/poky/${RELEASE}/${SETUPSCRIPT} ]; then
     # Buildtools has been installed so enable it
-    . /opt/poky/3.1.13/${SETUPSCRIPT} || exit 1
-elif [ -e /opt/poky/4.0/${SETUPSCRIPT} ]; then
+    . /opt/poky/${RELEASE}/${SETUPSCRIPT} || exit 1
+elif [ -e /opt/poky/${RELEASE}/${SETUPSCRIPT} ]; then
     # Buildtools(-make) has been installed so enable it
-    . /opt/poky/4.0/${SETUPSCRIPT} || exit 1
+    . /opt/poky/${RELEASE}/${SETUPSCRIPT} || exit 1
 fi
 
 exec "$@"


### PR DESCRIPTION
Without this, we're unable to setup the standalone sdk and CI breaks even worse.

Signed-off-by: Eilís 'pidge' Ní Fhlannagáin <pidge@baylibre.com>