### PR TITLE
deploy: set default distro to Ubuntu-22.04

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -38,7 +38,7 @@ jobs:
     env:
       BASE_DISTRO: ${{ matrix.base_distro }}
       REPO: crops/poky
-      DEFAULT_DISTRO: ubuntu-18.04
+      DEFAULT_DISTRO: ubuntu-22.04
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 


### PR DESCRIPTION
Ubuntu 18.04 can no longer build the poky/master branch because it requires Python 3.8+.  Switch the `DEFAULT_DISTRO` to a later Ubuntu release so that `crops/poky:latest` becomes something usable.

Signed-off-by: Patrick Williams <patrick@stwcx.xyz>