### PR TITLE
fedora,opensuse: sync with yocto-dockerfiles

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -27,7 +27,11 @@ jobs:
                       debian-10,
                       debian-11,
                       fedora-36,
+                      fedora-37,
+                      fedora-38,
+                      fedora-39,
                       opensuse-15.4,
+                      opensuse-15.5,
                       ubuntu-18.04,
                       ubuntu-20.04,
                       ubuntu-22.04

--- a/tests/distro-check.sh
+++ b/tests/distro-check.sh
@@ -3,20 +3,10 @@
 # distro-check.sh
 #
 # Copyright (C) 2020 Intel Corporation
+# Copyright (C) 2024 Konsulko Group
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License version 2 as
-# published by the Free Software Foundation.
+# SPDX-License-Identifier: GPL-2.0-only
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-
 # Verify that the distro inside the container matches the one we expect based
 # on the build
 
@@ -32,12 +22,12 @@ distros["centos-7"]="CentOS Linux 7 (Core)"
 distros["debian-9"]="Debian GNU/Linux 9 (stretch)"
 distros["debian-10"]="Debian GNU/Linux 10 (buster)"
 distros["debian-11"]="Debian GNU/Linux 11 (bullseye)"
-distros["fedora-34"]="Fedora 34 (Container Image)"
-distros["fedora-35"]="Fedora Linux 35 (Container Image)"
 distros["fedora-36"]="Fedora Linux 36 (Container Image)"
-distros["opensuse-15.2"]="openSUSE Leap 15.2"
-distros["opensuse-15.3"]="openSUSE Leap 15.3"
+distros["fedora-37"]="Fedora Linux 37 (Container Image)"
+distros["fedora-38"]="Fedora Linux 38 (Container Image)"
+distros["fedora-39"]="Fedora Linux 39 (Container Image)"
 distros["opensuse-15.4"]="openSUSE Leap 15.4"
+distros["opensuse-15.5"]="openSUSE Leap 15.5"
 distros["ubuntu-18.04"]="Ubuntu 18.04"
 distros["ubuntu-20.04"]="Ubuntu 20.04"
 distros["ubuntu-22.04"]="Ubuntu 22.04"


### PR DESCRIPTION
Add:
* fedora-37
* fedora-38
* feodra-39
* opensuse-15.5

NOTE: python2 is no longer supported. If you still need it,
      build your own containers.