### PR TITLE
Bugfix/11385

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,4 +69,7 @@ point.
   pokyuser@3bbac563cacd:/workdir$
   ```
   At this point you should be able to follow the same instructions as described
-  in https://docs.yoctoproject.org/brief-yoctoprojectqs/index.html
+  in https://docs.yoctoproject.org/brief-yoctoprojectqs/index.html#building-your-image to build an image.
+
+  Note that the container should not be used to clone Poky or obtain any other meta-data, which must be done
+  _outside_ the container using common tools like Git, as stated in https://docs.yoctoproject.org/brief-yoctoprojectqs/index.html#use-git-to-clone-poky

--- a/README.md
+++ b/README.md
@@ -57,12 +57,14 @@ point.
     docker run --rm -it -v myvolume:/workdir crops/poky --workdir=/workdir
     ```
 
-  Let's discuss the options:
-  * **_--workdir=/workdir_**: This causes the container to start in the directory
+  Available options:
+  * **_--help_**: show help message and exit.
+  * **_--workdir=WORKDIR_**: This causes the container to start in the directory
     specified. This can be any directory in the container. The container will also use the uid and gid
     of the workdir as the uid and gid of the user in the container.
+  * **_--id=ID_**: uid and gid to use for the user inside the container. It should be in the form uid:gid.
 
-  This should put you at a prompt similar to:
+  The previous example should put you at a prompt similar to:
   ```
   pokyuser@3bbac563cacd:/workdir$
   ```

--- a/poky-entry.py
+++ b/poky-entry.py
@@ -25,7 +25,7 @@ import os
 parser = argparse.ArgumentParser()
 parser.add_argument('--workdir', default='/home/pokyuser',
                     help='The active directory once the container is running. '
-                         'In the abscence of the "id" argument, the uid and '
+                         'In the absence of the "id" argument, the uid and '
                          'gid of the workdir will also be used for the user '
                          'in the container.')
 


### PR DESCRIPTION
This series fixes the following issue reported on the Yocto Project Bugzilla:
https://bugzilla.yoctoproject.org/show_bug.cgi?id=11385

which is not a bug as such, but an improvement in the documentation for beginners.

When at it, a trivial typo has been fixed in the help message, and the rest of the options has been added. They follow the format used in the example for consistency (’option=val’, and not 'option val' as stated in the help message).