### PR TITLE
distro-entry.sh: remove hardcoded SDK release number

### DIFF
--- a/distro-entry.sh
+++ b/distro-entry.sh
@@ -4,22 +4,15 @@
 #
 # SPDX-License-Identifier: GPL-2.0-only
 
-RELEASE="4.1"
+ARCH="$(uname -m)"
+
+# Search the environment setup script with the higher version number
+SETUPSCRIPT="$(find /opt/poky -type f -name environment-setup-${ARCH}-pokysdk-linux 2>/dev/null | sort -r | head -n 1)"
 
 # This entry point is so that we can do distro specific changes to the launch.
-if [ "$(uname -m)" = "aarch64" ]; then
-    SETUPSCRIPT="environment-setup-aarch64-pokysdk-linux"
-elif [ "$(uname -m)" = "x86_64" ]; then
-    SETUPSCRIPT="environment-setup-x86_64-pokysdk-linux"
-fi
-
-# This entry point is so that we can do distro specific changes to the launch.
-if [ -e /opt/poky/${RELEASE}/${SETUPSCRIPT} ]; then
+if [ ! -z "${SETUPSCRIPT}" ]; then
     # Buildtools has been installed so enable it
-    . /opt/poky/${RELEASE}/${SETUPSCRIPT} || exit 1
-elif [ -e /opt/poky/${RELEASE}/${SETUPSCRIPT} ]; then
-    # Buildtools(-make) has been installed so enable it
-    . /opt/poky/${RELEASE}/${SETUPSCRIPT} || exit 1
+    . ${SETUPSCRIPT} || exit 1
 fi
 
 exec "$@"


### PR DESCRIPTION
Remove the hardcoded Poky SDK release number from the distro-entry.sh script, which will select automatically the environment setup script with the higher release version in its path.