### PR TITLE
workflows: add ubuntu-24.04 and opensuse-15.6

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -30,9 +30,11 @@ jobs:
                       fedora-40,
                       opensuse-15.4,
                       opensuse-15.5,
+                      opensuse-15.6,
                       ubuntu-18.04,
                       ubuntu-20.04,
-                      ubuntu-22.04
+                      ubuntu-22.04,
+                      ubuntu-24.04
         ]
     env:
       BASE_DISTRO: ${{ matrix.base_distro }}

--- a/tests/distro-check.sh
+++ b/tests/distro-check.sh
@@ -18,7 +18,6 @@ declare -A distros
 
 distros["alma-8"]="AlmaLinux 8"
 distros["alma-9"]="AlmaLinux 9"
-distros["debian-9"]="Debian GNU/Linux 9 (stretch)"
 distros["debian-10"]="Debian GNU/Linux 10 (buster)"
 distros["debian-11"]="Debian GNU/Linux 11 (bullseye)"
 distros["debian-12"]="Debian GNU/Linux 12 (bookworm)"
@@ -26,9 +25,11 @@ distros["fedora-39"]="Fedora Linux 39 (Container Image)"
 distros["fedora-40"]="Fedora Linux 40 (Container Image)"
 distros["opensuse-15.4"]="openSUSE Leap 15.4"
 distros["opensuse-15.5"]="openSUSE Leap 15.5"
+distros["opensuse-15.6"]="openSUSE Leap 15.6"
 distros["ubuntu-18.04"]="Ubuntu 18.04"
 distros["ubuntu-20.04"]="Ubuntu 20.04"
 distros["ubuntu-22.04"]="Ubuntu 22.04"
+distros["ubuntu-24.04"]="Ubuntu 24.04 LTS"
 
 # If the distro is unknown it is a failure
 if [ "${distros[${BASE_DISTRO}]}" = "" ]; then


### PR DESCRIPTION
https://canonical.com/blog/canonical-releases-ubuntu-24-04-noble-numbat

https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/15.6/

Drop debian-9 from distro-check.sh; accidentally left behind.